### PR TITLE
Fix for installs not made at root of web server

### DIFF
--- a/about.php
+++ b/about.php
@@ -10,8 +10,8 @@
 </head>
 <body>
 
-    <form action="/" method="get">  
-    <a href="/"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo urldecode($query) ?>">
+    <form action="./" method="get">  
+    <a href="./"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo urldecode($query) ?>">
     <input type="submit" value="Ribbbit!">
     </form>
     <hr>

--- a/choose_edition.php
+++ b/choose_edition.php
@@ -20,36 +20,36 @@ if( isset( $_GET['loc'] ) ) {
     <center>
     <small>Basic HTML Google News for vintage computers. Built by <a href="https://youtube.com/ActionRetro" target="_blank"><b>Action Retro</b></a> on YouTube. Tested on Netscape 1.1 through 4 on a Mac SE/30.</small>
     <p><h2>CHOOSE YOUR EDITION:</h2></p>
-    <p><a href='/index.php?section=nation&loc=US'>United States</a></p>
-    <p><a href='/index.php?section=nation&loc=JP'>Japan</a></p>
-    <p><a href='/index.php?section=nation&loc=UK'>United Kingdom</a></p>
+    <p><a href='./index.php?section=nation&loc=US'>United States</a></p>
+    <p><a href='./index.php?section=nation&loc=JP'>Japan</a></p>
+    <p><a href='./index.php?section=nation&loc=UK'>United Kingdom</a></p>
     <p>Spain (RIP)</p>
-    <p><a href='/index.php?section=nation&loc=CA'>Canada</a></p>
-    <p><a href='/index.php?section=nation&loc=DE'>Deutschland</a></p>
-    <p><a href='/index.php?section=nation&loc=IT'>Italia</a></p>
-    <p><a href='/index.php?section=nation&loc=FR'>France</a></p>
-    <p><a href='/index.php?section=nation&loc=AU'>Australia</a></p>
-    <p><a href='/index.php?section=nation&loc=TW'>Taiwan</a></p>
-    <p><a href='/index.php?section=nation&loc=NL'>Nederland</a></p>
-    <p><a href='/index.php?section=nation&loc=BR'>Brasil</a></p>
-    <p><a href='/index.php?section=nation&loc=TR'>Turkey</a></p>
-    <p><a href='/index.php?section=nation&loc=BE'>Belgium</a></p>
-    <p><a href='/index.php?section=nation&loc=GR'>Greece</a></p>
-    <p><a href='/index.php?section=nation&loc=IN'>India</a></p>
-    <p><a href='/index.php?section=nation&loc=MX'>Mexico</a></p>
-    <p><a href='/index.php?section=nation&loc=DK'>Denmark</a></p>
-    <p><a href='/index.php?section=nation&loc=AR'>Argentina</a></p>
-    <p><a href='/index.php?section=nation&loc=CH'>Switzerland</a></p>
-    <p><a href='/index.php?section=nation&loc=CL'>Chile</a></p>
-    <p><a href='/index.php?section=nation&loc=AT'>Austria</a></p>
-    <p><a href='/index.php?section=nation&loc=KR'>Korea</a></p>
-    <p><a href='/index.php?section=nation&loc=IE'>Ireland</a></p>
-    <p><a href='/index.php?section=nation&loc=CO'>Colombia</a></p>
-    <p><a href='/index.php?section=nation&loc=PL'>Poland</a></p>
-    <p><a href='/index.php?section=nation&loc=PT'>Portugal</a></p>
-    <p><a href='/index.php?section=nation&loc=PK'>Pakistan</a></p>
+    <p><a href='./index.php?section=nation&loc=CA'>Canada</a></p>
+    <p><a href='./index.php?section=nation&loc=DE'>Deutschland</a></p>
+    <p><a href='./index.php?section=nation&loc=IT'>Italia</a></p>
+    <p><a href='./index.php?section=nation&loc=FR'>France</a></p>
+    <p><a href='./index.php?section=nation&loc=AU'>Australia</a></p>
+    <p><a href='./index.php?section=nation&loc=TW'>Taiwan</a></p>
+    <p><a href='./index.php?section=nation&loc=NL'>Nederland</a></p>
+    <p><a href='./index.php?section=nation&loc=BR'>Brasil</a></p>
+    <p><a href='./index.php?section=nation&loc=TR'>Turkey</a></p>
+    <p><a href='./index.php?section=nation&loc=BE'>Belgium</a></p>
+    <p><a href='./index.php?section=nation&loc=GR'>Greece</a></p>
+    <p><a href='./index.php?section=nation&loc=IN'>India</a></p>
+    <p><a href='./index.php?section=nation&loc=MX'>Mexico</a></p>
+    <p><a href='./index.php?section=nation&loc=DK'>Denmark</a></p>
+    <p><a href='./index.php?section=nation&loc=AR'>Argentina</a></p>
+    <p><a href='./index.php?section=nation&loc=CH'>Switzerland</a></p>
+    <p><a href='./index.php?section=nation&loc=CL'>Chile</a></p>
+    <p><a href='./index.php?section=nation&loc=AT'>Austria</a></p>
+    <p><a href='./index.php?section=nation&loc=KR'>Korea</a></p>
+    <p><a href='./index.php?section=nation&loc=IE'>Ireland</a></p>
+    <p><a href='./index.php?section=nation&loc=CO'>Colombia</a></p>
+    <p><a href='./index.php?section=nation&loc=PL'>Poland</a></p>
+    <p><a href='./index.php?section=nation&loc=PT'>Portugal</a></p>
+    <p><a href='./index.php?section=nation&loc=PK'>Pakistan</a></p>
     </center>
-    <small><a href="/index.php?loc=<?php echo $loc ?>">< Back to <font color="#9400d3">68k.news</font> <?php echo $loc ?>front page</a></small>
+    <small><a href="./index.php?loc=<?php echo $loc ?>">< Back to <font color="#9400d3">68k.news</font> <?php echo $loc ?>front page</a></small>
 	<p><center><small>Powered by Mozilla Readability (Andres Rey PHP Port) and SimplePie</small></p>
 </body>
 </html>

--- a/image.php
+++ b/image.php
@@ -39,7 +39,7 @@
  <body">
     <small><a href="<?php echo $_SERVER['HTTP_REFERER'] . '?loc=' . strtoupper($loc) ?>">< Back to article</a></small>
     <p><small><b>Viewing image:</b> <?php echo $url ?></small></p>
-    <img src="/image_compressed.php?i=<?php echo $url; ?>">
+    <img src="./image_compressed.php?i=<?php echo $url; ?>">
     <br><br>
     <small><a href="<?php echo $_SERVER['HTTP_REFERER'] . '?loc=' . strtoupper($loc) ?>">< Back to article</a></small>
  </body>

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ if(isset( $_GET['q'])) { // if there's a search query, show the results for it
             // result link, redirected through our proxy
             $result_link = explode('class="result__a" href="', $result_blocks[$x])[1];
             $result_topline = explode('">', $result_link);
-            $result_link = str_replace( '//duckduckgo.com/l/?uddg=', '/read.php?a=', $result_topline[0]);
+            $result_link = str_replace( '//duckduckgo.com/l/?uddg=', './read.php?a=', $result_topline[0]);
             // result title
             $result_title = str_replace("</a>","",explode("\n", $result_topline[1]));
             // result display url
@@ -66,8 +66,8 @@ function clean_str($str) {
 
 <?php if($show_results) { // there's a search query in q, so show search results ?>
 
-    <form action="/" method="get">
-    <a href="/"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo urldecode($query) ?>">
+    <form action="./" method="get">
+    <a href="./"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo urldecode($query) ?>">
     <input type="submit" value="Ribbbit!">
     </form>
     <hr>
@@ -81,7 +81,7 @@ function clean_str($str) {
     <center><h3>The Search Engine for Vintage Computers</h3></center>
     <br><br>
     <center>
-    <form action="/" method="get">
+    <form action="./" method="get">
     Leap to: <input type="text" size="30" name="q"><br>
     <input type="submit" value="Ribbbit!">
     </center>

--- a/read.php
+++ b/read.php
@@ -47,7 +47,7 @@ try {
     $readable_article = str_replace( 'em>', 'i>', $readable_article ); //change <em> to <i>
     
     $readable_article = clean_str($readable_article);
-    $readable_article = str_replace( 'href="http', 'href="/read.php?a=http', $readable_article ); //route links through proxy
+    $readable_article = str_replace( 'href="http', 'href="./read.php?a=http', $readable_article ); //route links through proxy
     
 } catch (ParseException $e) {
     $error_text .= 'Sorry! ' . $e->getMessage() . '<br>';
@@ -73,8 +73,8 @@ function clean_str($str) {
  </head>
  <body>
     <p>
-        <form action="/read.php" method="get">
-        <a href="/">Back to <b><font color="#008000">Frog</font><font color="000000">Find!</font></a></b> | Browsing URL: <input type="text" size="38" name="a" value="<?php echo $article_url ?>">
+        <form action="./read.php" method="get">
+        <a href="./">Back to <b><font color="#008000">Frog</font><font color="000000">Find!</font></a></b> | Browsing URL: <input type="text" size="38" name="a" value="<?php echo $article_url ?>">
         <input type="submit" value="Go!">
         </form>
     </p>


### PR DESCRIPTION
Hi,

My test install was made on an existing server but not at the root. For instance: `https://my.host.name/frogfind/` instead of `https://my.frogfind.name/` .

The problem is that all redirection links are hard-coded to go to the root of the system (i.e. to `"/read.php"` etc.), which then only works if you installed FrogFind at the root, which is not my case.

This fixes that.