### PR TITLE
convert special chars to avoid xss

### DIFF
--- a/image.php
+++ b/image.php
@@ -4,7 +4,7 @@
     $loc = "US";
 
     if( isset( $_GET['loc'] ) ) {
-        $loc = strtoupper($_GET["loc"]);
+        $loc = urlencode(strtoupper($_GET["loc"]));
     }
     
     //get the image url
@@ -38,8 +38,8 @@
  </head>
  <body">
     <small><a href="<?php echo $_SERVER['HTTP_REFERER'] . '?loc=' . strtoupper($loc) ?>">< Back to article</a></small>
-    <p><small><b>Viewing image:</b> <?php echo $url ?></small></p>
-    <img src="/image_compressed.php?i=<?php echo $url; ?>">
+    <p><small><b>Viewing image:</b> <?php echo htmlspecialchars($url, ENT_QUOTES, 'UTF-8') ?></small></p>
+    <img src="/image_compressed.php?i=<?php echo urlencode($url); ?>">
     <br><br>
     <small><a href="<?php echo $_SERVER['HTTP_REFERER'] . '?loc=' . strtoupper($loc) ?>">< Back to article</a></small>
  </body>

--- a/index.php
+++ b/index.php
@@ -67,12 +67,12 @@ function clean_str($str) {
 <?php if($show_results) { // there's a search query in q, so show search results ?>
 
     <form action="/" method="get">
-    <a href="/"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo urldecode($query) ?>">
+    <a href="/"><font size=6 color="#008000">Frog</font><font size=6 color="#000000">Find!</font></a> Leap again: <input type="text" size="30" name="q" value="<?php echo htmlspecialchars(urldecode($query), ENT_QUOTES, 'UTF-8') ?>">
     <input type="submit" value="Ribbbit!">
     </form>
     <hr>
     <br>
-    <center>Search Results for <b><?php echo strip_tags(urldecode($query)) ?></b></center>
+    <center>Search Results for <b><?php echo htmlspecialchars(urldecode($query), ENT_QUOTES, 'UTF-8') ?></b></center>
     <br>
     <?php echo $final_result_html ?>
     

--- a/read.php
+++ b/read.php
@@ -7,7 +7,7 @@ $error_text = "";
 $loc = "US";
 
 if( isset( $_GET['loc'] ) ) {
-    $loc = strtoupper($_GET["loc"]);
+    $loc = urlencode(strtoupper($_GET["loc"]));
 }
 
 if( isset( $_GET['a'] ) ) {
@@ -74,7 +74,7 @@ function clean_str($str) {
  <body>
     <p>
         <form action="/read.php" method="get">
-        <a href="/">Back to <b><font color="#008000">Frog</font><font color="000000">Find!</font></a></b> | Browsing URL: <input type="text" size="38" name="a" value="<?php echo $article_url ?>">
+        <a href="/">Back to <b><font color="#008000">Frog</font><font color="000000">Find!</font></a></b> | Browsing URL: <input type="text" size="38" name="a" value="<?php echo htmlspecialchars($article_url, ENT_QUOTES, 'UTF-8') ?>">
         <input type="submit" value="Go!">
         </form>
     </p>


### PR DESCRIPTION
Hi!

I watch your YouTube channel and really enjoy your content. I think these projects for enabling older machines to use the modern web are great so I thought I should have a quick look to see if I can contribute some advice.

I don't know if you're familiar with the concept of [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) or cross-site scripting attacks. In short they allow strangers to use your website as a disguise to run scams, phish for password etc.

As it stands, user inputs aren't safely escaped, which means it is possible to use special characters, like double-quotes, to inject markup or even JavaScript code into the site.

Fore example searching for `"><script>alert('hi i\'m friendly neighbourhood XSS attack :)');</script><img src="` will actually run that JavaScript code. Where it really becomes a critical issue is that you can take that search query link and send it to someone: [http://frogfind.com/?q=%22%3E%3Cscript%3Ealert%28%27hi+i%5C%27m+your+friendly+neighbourhood+XSS+attack+%3A%29%27%29%3B%3C%2Fscript%3E%3Cimg+src%3D%22](http://frogfind.com/?q=%22%3E%3Cscript%3Ealert%28%27hi+i%5C%27m+your+friendly+neighbourhood+XSS+attack+%3A%29%27%29%3B%3C%2Fscript%3E%3Cimg+src%3D%22) 
Most users won't study a link and just open it and that's where I use your trustworthy site to run my code on the end users machine. That's when I could ask for a password etc...

The changes I committed will prevent these kind of XSS attacks. While you did use `strip_tags` for the text output you didn't escape the query value within the input value, which as you can see above is very easy to break out of. Aside from being more secure `htmlspecialchars` will also allow users to search for HTML tags for example `<title>` and it will now show what you searched as it doesn't strip tags but instead converts the `<` and `>` to safe html entities which won't be interpreted as html.

Hope this helps. Keep up the great work :)

